### PR TITLE
feat(auth): add signup page and improve login/signup experience

### DIFF
--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -60,7 +60,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 					// Not logged in...
 					setUser(null);
 					try {
-						if (router.pathname !== '/login') {
+						// 允許訪問登入和註冊頁面
+						const publicPaths = ['/login', '/signup'];
+						if (!publicPaths.includes(router.pathname)) {
 							router.push('/login');
 						}
 					} catch (error) {
@@ -68,10 +70,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 					}
 				}
 
-				setInitialLoading(false);
-			}),
-		[auth, router],
-	);
+					setInitialLoading(false);
+				}),
+				[router],
+			);
 
 	useEffect(() => {
 		let logoutTimer: NodeJS.Timeout;
@@ -163,7 +165,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 			error,
 			resetError,
 		}),
-		[user, loading, error],
+		[user, loading, error, signIn, signUp],
 	);
 
 	return (

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -7,7 +7,7 @@ import {
 	User,
 } from 'firebase/auth';
 import { useRouter } from 'next/router';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { auth } from '../firebase';
 
 // 自動登出時間設置（毫秒）
@@ -70,10 +70,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 					}
 				}
 
-					setInitialLoading(false);
-				}),
-				[router],
-			);
+				setInitialLoading(false);
+			}),
+		[router],
+	);
 
 	useEffect(() => {
 		let logoutTimer: NodeJS.Timeout;
@@ -96,50 +96,54 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 		};
 	}, [user]);
 
-	const resetError = () => {
+	const resetError = useCallback(() => {
 		setError(null);
-	};
+	}, []);
 
-	const signIn = async (email: string, password: string) => {
-		setLoading(true);
-		resetError();
-		try {
-			const userCredential = await signInWithEmailAndPassword(auth, email, password);
-			setUser(userCredential.user);
-			return { success: true };
-		} catch (error) {
-			const authError = error as AuthError;
-			console.error('登入錯誤:', authError);
-			// 根據 Firebase 錯誤代碼進行處理，例如顯示錯誤訊息給使用者，或者根據錯誤代碼進行其他動作
-			return {
-				success: false,
-				error: authError.code,
-			};
-		} finally {
-			setLoading(false);
-		}
-	};
+	const signIn = useCallback(
+		async (email: string, password: string) => {
+			setLoading(true);
+			resetError();
+			try {
+				const userCredential = await signInWithEmailAndPassword(auth, email, password);
+				setUser(userCredential.user);
+				return { success: true };
+			} catch (error) {
+				const authError = error as AuthError;
+				console.error('登入錯誤:', authError);
+				return {
+					success: false,
+					error: authError.code,
+				};
+			} finally {
+				setLoading(false);
+			}
+		},
+		[resetError],
+	);
 
-	const signUp = async (email: string, password: string) => {
-		setLoading(true);
-		resetError();
-		try {
-			const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-			console.log(userCredential.user);
-			setUser(userCredential.user);
-			return { success: true };
-		} catch (error) {
-			const authError = error as AuthError;
-			console.error('註冊錯誤:', authError);
-			// 根據 Firebase 錯誤代碼進行處理，例如顯示錯誤訊息給使用者，或者根據錯誤代碼進行其他動作
-			return {
-				success: false,
-				error: authError.code,
-			};
-		} finally {
-			setLoading(false);
-		}
-	};
+	const signUp = useCallback(
+		async (email: string, password: string) => {
+			setLoading(true);
+			resetError();
+			try {
+				const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+				console.log(userCredential.user);
+				setUser(userCredential.user);
+				return { success: true };
+			} catch (error) {
+				const authError = error as AuthError;
+				console.error('註冊錯誤:', authError);
+				return {
+					success: false,
+					error: authError.code,
+				};
+			} finally {
+				setLoading(false);
+			}
+		},
+		[resetError],
+	);
 
 	const logout = async () => {
 		setLoading(true);
@@ -165,7 +169,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 			error,
 			resetError,
 		}),
-		[user, loading, error, signIn, signUp],
+		[user, loading, error, signIn, signUp, resetError],
 	);
 
 	return (

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -16,9 +16,9 @@ type Inputs = {
 	password: string;
 };
 
-function Login() {
+function Signup() {
 	const router = useRouter();
-	const { signIn, loading } = useAuth();
+	const { signUp, loading } = useAuth();
 	const [message, setMessage] = useState({ type: '', content: '' });
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -28,7 +28,6 @@ function Login() {
 		formState: { errors },
 	} = useForm<Inputs>();
 
-	// 統一的錯誤處理函數
 	const handleAuthError = (error: FirebaseAuthError) => {
 		switch (error.code) {
 			case 'auth/email-already-in-use':
@@ -51,10 +50,10 @@ function Login() {
 		setMessage({ type: '', content: '' });
 
 		try {
-			const result = await signIn(email, password);
+			const result = await signUp(email, password);
 			if (result.success) {
-				router.push('/');
-				setMessage({ type: 'success', content: '登入成功！即將跳轉...' });
+				setMessage({ type: 'success', content: '註冊成功！即將跳轉...' });
+				setTimeout(() => router.push('/'), 1500);
 			} else {
 				setMessage(handleAuthError({ code: result.error || '', message: '' }));
 			}
@@ -62,19 +61,19 @@ function Login() {
 			const firebaseError = error as FirebaseAuthError;
 			setMessage(handleAuthError(firebaseError));
 		} finally {
-			setIsSubmitting(false); // 確保在操作完成後重置狀態
+			setIsSubmitting(false);
 		}
 	};
 
 	return (
 		<div className='relative flex h-screen w-screen flex-col bg-black md:items-center md:justify-center md:bg-transparent'>
 			<Head>
-				<title>Netflixx</title>
+				<title>註冊 - Netflixx</title>
 				<link rel='icon' href='/logo.svg' />
 			</Head>
 			<Image
 				src='/loginImg.webp'
-				alt='Login page background image'
+				alt='Signup page background image'
 				className='-z-10 hidden brightness-[50%] sm:inline object-cover absolute inset-0 h-screen w-screen '
 				fill
 				sizes='100vw'
@@ -94,9 +93,10 @@ function Login() {
 
 			<form
 				onSubmit={handleSubmit(onSubmit)}
+				onClick={(e) => e.stopPropagation()}
 				className='relative mt-24 space-y-8 py-10 px-6 rounded bg-black/75 md:mt-0 md:max-w-md md:px-14'
 			>
-				<h1 className='text-4xl font-semibold '>登入</h1>
+				<h1 className='text-4xl font-semibold '>註冊</h1>
 				<div className='space-y-4'>
 					<label className='inline-block w-full'>
 						<input
@@ -104,9 +104,8 @@ function Login() {
 							placeholder='Email'
 							className='input'
 							{...register('email', {
-								required: '請輸入有效的電子郵件地址。', // 添加了自定義錯誤訊息
+								required: '請輸入有效的電子郵件地址。',
 								pattern: {
-									// 添加了 email 格式驗證
 									value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
 									message: '請輸入有效的電子郵件地址。',
 								},
@@ -158,27 +157,18 @@ function Login() {
 					{loading ? (
 						<Loader color='fill-white' />
 					) : (
-						<div className='flex items-center justify-center space-x-2'>登入</div>
+						<div className='flex items-center justify-center space-x-2'>註冊</div>
 					)}
 				</button>
 
-				<div className='mt-6 text-[gray] text-center'>
-					尚未加入Netflixx? {'  '}
+				<div className='text-[gray] text-center'>
+					已經有帳號? {'  '}
 					<button
 						type='button'
-						onClick={async (e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							console.log('Navigating to signup...');
-							try {
-								await router.replace('/signup');
-							} catch (err) {
-								console.error('Navigation error:', err);
-							}
-						}}
-						className='text-white hover:underline inline-block ml-1'
+						onClick={() => router.push('/login')}
+						className='text-white hover:underline '
 					>
-						馬上註冊。
+						立即登入。
 					</button>
 				</div>
 			</form>
@@ -186,4 +176,4 @@ function Login() {
 	);
 }
 
-export default Login;
+export default Signup;


### PR DESCRIPTION
###  Why
- 登入與註冊原本共用同一頁面，使用者體驗不佳。
- 註冊後缺乏導向與一致的錯誤提示。
- useAuth 依賴項不完整，可能導致不必要的 re-render。

###  Changes
- 新增獨立註冊頁面 `/signup`
- 登入頁新增「馬上註冊」導向 `/signup`
- useAuth 移除多餘的 `auth` 依賴，補齊 `useMemo` 依賴項
- 新增 publicPaths：`['/login', '/signup']`

###  Acceptance Criteria
- [x] `/login` 點擊「馬上註冊」可正確導向 `/signup`
- [x] `/signup` 註冊成功自動導向首頁 `/`
- [x] useAuth hook 無 ESLint 依賴警告
- [x] 登入與註冊錯誤訊息一致
