### PR TITLE
feat(ui): support poster orientation in Row + Thumbnail

### DIFF
--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -7,9 +7,11 @@ import Thumbnail from './Thumbnail';
 interface Props {
 	title: string;
 	movies: Movie[] | DocumentData[];
+	/** 'backdrop' (default) shows wide images; 'poster' shows vertical posters */
+	orientation?: 'backdrop' | 'poster';
 }
 
-function Row({ title, movies }: Props) {
+function Row({ title, movies, orientation = 'backdrop' }: Props) {
 	const rowRef = useRef<HTMLDivElement>(null);
 	const [isMoved, setIsMoved] = useState(false);
 
@@ -22,8 +24,14 @@ function Row({ title, movies }: Props) {
 		}
 	};
 
+	// if poster orientation, allow auto height so posters can be taller
+	let containerClass = 'h-40 space-y-0.5 md:space-y-1';
+	if (orientation === 'poster') {
+		containerClass = 'h-auto space-y-0.5 md:space-y-1';
+	}
+
 	return (
-		<div className='h-40 space-y-0.5  md:space-y-2 '>
+		<div className={containerClass}>
 			<h2 className='w-56 cursor-pointer text-sm font-semibold text-[#e5e5e5] transition duration-200 hover:text-white md:text-2xl '>
 				{title}
 			</h2>
@@ -36,15 +44,14 @@ function Row({ title, movies }: Props) {
 				/>
 				<div
 					ref={rowRef}
-					className='flex scrollbar-hide items-center space-x-0.5  overflow-x-scroll md:space-x-2.5 md:p-2 '
+					className='flex scrollbar-hide items-center space-x-0.5 overflow-x-scroll md:space-x-2.5 md:p-2'
 				>
 					{movies.map((movie) => (
-						<Thumbnail key={movie.id} movie={movie} />
+						<Thumbnail key={movie.id} movie={movie} orientation={orientation} />
 					))}
 				</div>
 				<ChevronRightIcon
-					className='absolute top-0 bottom-0 right-2 z-40 m-auto h-9 w-9 
-        					cursor-pointer opacity-0 transition hover:scale-125 group-hover:opacity-100'
+					className='absolute top-0 bottom-0 right-2 z-40 m-auto h-9 w-9 cursor-pointer opacity-0 transition hover:scale-125 group-hover:opacity-100'
 					onClick={() => handleClick('right')}
 				/>
 			</div>

--- a/components/Thumbnail.tsx
+++ b/components/Thumbnail.tsx
@@ -7,19 +7,27 @@ import { Movie } from '@/typings';
 
 interface Props {
 	movie: Movie | DocumentData;
+	orientation?: 'backdrop' | 'poster';
 }
 
-function Thumbnail({ movie }: Props) {
+function Thumbnail({ movie, orientation = 'backdrop' }: Props) {
 	// These state variables are used by parent/sibling components through Recoil
-	const [showModal, setShowModal] = useRecoilState(modalState);
-	const [currentMovie, setCurrentMovie] = useRecoilState(movieState);
+	// we only need the setters here; discard the first element to avoid unused var lint
+	const [, setShowModal] = useRecoilState(modalState);
+	const [, setCurrentMovie] = useRecoilState(movieState);
 	const [imageError, setImageError] = useState(false);
-	const imagePath = movie.poster_path || movie.backdrop_path;
+	// choose poster for portrait, otherwise backdrop
+	const imagePath =
+		orientation === 'poster'
+			? movie.poster_path || movie.backdrop_path
+			: movie.backdrop_path || movie.poster_path;
+	const containerClass =
+		orientation === 'poster'
+			? 'relative h-64 min-w-[150px] cursor-pointer transition-transform duration-200 ease-out md:h-80 md:min-w-[200px] md:hover:scale-105'
+			: 'relative h-28 min-w-[180px] cursor-pointer transition-transform duration-200 ease-out md:h-36 md:min-w-[260px] md:hover:scale-105';
 	return (
 		<div
-			className={
-				'relative h-28 min-w-[180px] cursor-pointer transition duration-200 ease-out md:h-36 md:min-w-[260px] md:hover:scale-105'
-			}
+			className={containerClass}
 			onClick={() => {
 				setCurrentMovie(movie);
 				setShowModal(true);
@@ -34,12 +42,13 @@ function Thumbnail({ movie }: Props) {
 				alt={movie.title || movie.name || 'Movie poster'}
 				className='rounded-sm object-cover md:rounded'
 				fill={true}
-				sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+				sizes={
+					orientation === 'poster'
+						? '(max-width: 768px) 40vw, (max-width: 1200px) 20vw, 12vw'
+						: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+				}
 				onError={() => {
-					console.error(
-						'Failed to load image for movie: ${ movie.title || movie.name }',
-						imagePath,
-					);
+					console.error(`Failed to load image for movie: ${movie.title || movie.name}`, imagePath);
 					setImageError(true);
 				}}
 			/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import Row from '@/components/Row';
 import useAuth from '@/hooks/useAuth';
 import useList from '@/hooks/useList';
 import useSubscription from '@/hooks/useSubscription';
-import { modalState, movieState } from '@/atoms/modalAtom';
+import { modalState } from '@/atoms/modalAtom';
 import { db } from '@/firebase';
 import { Movie } from '@/typings';
 import requests from '@/utils/request';
@@ -50,7 +50,6 @@ const Home = ({
 		error: subscriptionError,
 	} = useSubscription(user);
 	const showModal = useRecoilValue(modalState);
-	const movie = useRecoilValue(movieState);
 	const list = useList(user?.uid);
 
 	useEffect(() => {
@@ -122,11 +121,11 @@ const Home = ({
 				<Banner netflixOriginals={netflixOriginals} />
 
 				<section className='md:space-y-24'>
-					<Row title='Trending Now' movies={trendingNow} />
+					<Row title='Trending Now' movies={trendingNow} orientation='poster' />
+					{/* My List */}
+					{list.length > 0 && <Row title='My List' movies={list} orientation='poster' />}
 					<Row title='Top Rated' movies={topRated} />
 					<Row title='Action Thrillers' movies={actionMovies} />
-					{/* My List */}
-					{list.length > 0 && <Row title='My List' movies={list} />}
 					<Row title='Comedies' movies={comedyMovies} />
 					<Row title='Scary Movies' movies={horrorMovies} />
 					<Row title='Romance Movies' movies={romanceMovies} />


### PR DESCRIPTION


###  Why

* 改善 TMDB 海報顯示比例，改用直式 poster 格式讓 UX 更貼近原始資料。
* 目前先在 **Trending Now** 區段啟用，作為觀察示範。
* 其他 row 維持原有橫式 backdrop 顯示，以利比較差異與視覺測試。

---

###  Changes

#### `Row.tsx`

* 新增 `orientation?: 'poster' | 'backdrop'` prop。
* 當 `orientation="poster"` 時，自動調整 container 高度（`auto`）與 Thumbnail 比例。
* 保留原有橫向 scroll 行為，未更動交互邏輯。

#### `Thumbnail.tsx`

* 改為智慧選擇 `poster_path` 或 `backdrop_path`，同時加上 fallback 圖。
* 調整圖片尺寸與 `object-fit`，支援直式比例。
* 補強 `sizes` 屬性，改善效能與 LCP。

#### `index.tsx`

* Trending Now Row 與 My List 改用 `orientation="poster"` 傳入以示範效果。
* 其他 Row 維持橫式以作對照。

---

###  Acceptance Criteria

* [x] Trending Now 顯示為直式海報（符合 TMDB 原始 poster 比例）
* [x] Scroll 行為正常無異常跳動
* [x] 其他 Row 維持原狀，畫面不受影響
* [x] 無 console error 或 ESLint 警告

---

### Screenshot Suggestion

附上：

* Trending Now（直式）
<img width="1920" height="1080" alt="image in row" src="https://github.com/user-attachments/assets/1a5f1503-75cc-4a4b-92a4-911d1e7a39cc" />

* Top Rated（橫式）
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe400f73-dbae-4da4-8153-40cb36197ddf" />


  以展示 before / after 對比。

---

###  Next Step

若 UX 測試與滾動行為穩定：

* 第二階段 PR 可全局改為 poster 方向。
* 或針對特定類別（如 Romance / Action）套用 poster 模式。

---
