### PR TITLE
feat(modal): add play/pause toggle with spinner feedback and accessib…

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -47,7 +47,13 @@ function Banner({ netflixOriginals }: Props) {
 				{movie?.overview}
 			</p>
 			<div className='flex space-x-3 '>
-				<button className='bannerButton bg-white text-black '>
+				<button
+					className='bannerButton bg-white text-black '
+					onClick={() => {
+						setCurrentMovie(movie);
+						setShowModal(true);
+					}}
+				>
 					<FaPlay className='h-4 w-4 text-black md:h-7 md:w-7' />
 					Play{' '}
 				</button>


### PR DESCRIPTION


## Why

* 原本的「播放」按鈕僅能啟動影片，沒有提供暫停或播放狀態切換。
* 使用者無法清楚辨識影片是否正在播放或已暫停，缺乏即時反饋。
* 缺少可訪問性（ARIA 狀態、螢幕閱讀器提示），不利無障礙體驗。
* 開始播放時沒有視覺提示，導致使用者誤以為未成功播放。
* 當沒有可用的預告片時，也缺乏明確錯誤處理。

---

## Changes

### 播放控制

* 新增 `playing` 狀態，並與 `ReactPlayer` 的 `playing` 屬性同步。
* 實作 **播放 / 暫停切換（Play ↔ Pause toggle）**，按鈕圖示與文字會動態更新。
* 加入 `onEnded` 事件監聽，影片播放結束後自動回復成「Play」。
* 新增 `isPlayingBtn` 狀態，在影片啟動時短暫顯示綠色 spinner 動畫（約 1.2 秒）。

### 視覺回饋

| 狀態          | 按鈕樣式                 | 視覺效果           |
| ----------- | -------------------- | -------------- |
| 播放中         | 綠底、白色 Pause icon     | 明確顯示正在播放       |
| 暫停中         | 白底、黑色 Play icon      | 保留 hover 與聚焦效果 |
| 播放啟動中       | 綠色 spinner 動畫        | 提供明確的即時回饋      |
| 按讚（ThumbUp） | icon 藍色高亮 + scale 放大 | 視覺強調互動成功       |

### 可訪問性（Accessibility）

* 新增 `aria-pressed` 屬性，會根據播放狀態即時更新。
* 按鈕文字與 icon 隨狀態切換（Play ↔ Pause），支援螢幕閱讀器。
* 維持 focus ring 與鍵盤操作支援。
* 播放、暫停、錯誤提示皆使用 toast 提供輔助回饋。

### 錯誤處理

* 當 `trailer` 不存在時顯示提示：「Trailer not available」。
* Firestore 的資料操作與訂閱事件加上 try/catch，避免潛在錯誤中斷 UI。

---

## Acceptance Criteria

* [x] 點擊「Play」能啟動播放，並出現綠色 spinner 動畫
* [x] 再次點擊切換為「Pause」並暫停影片
* [x] 預告片播放結束後自動回復「Play」狀態
* [x] `aria-pressed` 狀態正確更新並通過 a11y 檢查
* [x] 沒有預告片時會顯示「Trailer not available」提示
* [x] 沒有 ESLint 或 TypeScript 錯誤
* [x] 其他功能（靜音、收藏、按讚）皆可正常使用

---
