### PR TITLE
feat(banner): improve RWD layout, image ratio, and official button st…

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -1,8 +1,8 @@
-import { InformationCircleIcon } from '@heroicons/react/outline';
 import Image from 'next/image';
 import { useRecoilState } from 'recoil';
 import React, { useEffect, useState } from 'react';
 import { FaPlay } from 'react-icons/fa';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { modalState, movieState } from '@/atoms/modalAtom';
 import { baseUrl } from '@/constants/movie';
 import { Movie } from '@/typings';
@@ -18,16 +18,19 @@ function Banner({ netflixOriginals }: Props) {
 	const [, setCurrentMovie] = useRecoilState(movieState);
 	const [isLoading, setIsLoading] = useState(true);
 	const [imageError, setImageError] = useState(false);
+	const isMobile = useIsMobile();
 
 	useEffect(() => {
 		setMovie(netflixOriginals[Math.floor(Math.random() * netflixOriginals.length)]);
 	}, [netflixOriginals]);
 
-	const imagePath = movie?.poster_path || movie?.backdrop_path;
+	const imagePath = isMobile
+		? movie?.poster_path || movie?.backdrop_path
+		: movie?.backdrop_path || movie?.poster_path;
 
 	return movie == null ? null : (
-		<div className=' flex flex-col space-y-2 py-16 md:space-y-4 lg:h-[65vh] lg:justify-end lg:pb-12'>
-			<div className='absolute top-0 left-0  h-[95vh] w-[98.5vw] -z-10'>
+		<div className='flex flex-col justify-end space-y-4 pt-[30vh] md:pt-[40vh] lg:h-[65vh] lg:pt-0'>
+			<div className='absolute left-0 top-0 -z-10 h-[95vh] w-[98.5vw]'>
 				<Image
 					src={imageError || !imagePath ? '/fallback-image.webp' : `${baseUrl}${imagePath}`}
 					alt={movie?.title || movie?.name || 'Movie banner'}
@@ -40,31 +43,52 @@ function Banner({ netflixOriginals }: Props) {
 					onLoadingComplete={() => setIsLoading(false)}
 				/>
 			</div>
-			<h1 className='text-2xl md:text-3xl lg:text-7xl'>
+
+			<h1 className='max-w-[70%] text-2xl font-bold leading-tight md:max-w-[60%] md:text-4xl lg:max-w-[50%] lg:text-7xl'>
 				{movie?.title || movie?.name || movie?.original_name}
 			</h1>
-			<p className='max-w-xs text-xs text-shadow-md md:max-w-lg md:text-lg lg:max-w-2xl lg:text-2xl  '>
+
+			<p className='line-clamp-3 max-w-xs text-xs text-shadow-md md:max-w-lg md:text-lg lg:max-w-2xl lg:text-2xl'>
 				{movie?.overview}
 			</p>
-			<div className='flex space-x-3 '>
+
+			<div className='mt-4 flex space-x-3'>
+				{/* Play 按鈕 */}
 				<button
-					className='bannerButton bg-white text-black '
+					className='flex items-center gap-x-2 rounded bg-white px-5 py-2 text-sm font-bold text-black transition hover:scale-[1.03] hover:bg-[#e6e6e6] active:scale-[0.97] md:px-8 md:py-2.5 md:text-lg'
 					onClick={() => {
 						setCurrentMovie(movie);
 						setShowModal(true);
 					}}
 				>
 					<FaPlay className='h-4 w-4 text-black md:h-7 md:w-7' />
-					Play{' '}
+					Play
 				</button>
+
+				{/*  More Info 按鈕 */}
 				<button
-					className='bannerButton bg-[gray]/70'
+					className='flex items-center gap-x-2 rounded bg-[gray]/70 px-5 py-2 text-sm font-semibold text-white transition hover:scale-[1.03] hover:bg-[gray]/50 active:scale-[0.97] md:px-8 md:py-2.5 md:text-lg'
 					onClick={() => {
 						setCurrentMovie(movie);
 						setShowModal(true);
 					}}
 				>
-					More Info <InformationCircleIcon className='h-5 w-5 md:h-8 md:w-8' />
+					<svg
+						viewBox='0 0 24 24'
+						width='24'
+						height='24'
+						fill='none'
+						xmlns='http://www.w3.org/2000/svg'
+						className='inline-block translate-y-[1px] md:h-7 md:w-7'
+					>
+						<path
+							fill='currentColor'
+							fillRule='evenodd'
+							clipRule='evenodd'
+							d='M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20M0 12a12 12 0 1 1 24 0 12 12 0 0 1-24 0m13-2v8h-2v-8zm-1-1.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3'
+						/>
+					</svg>
+					More Info
 				</button>
 			</div>
 		</div>

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 768) {
+	const [isMobile, setIsMobile] = useState(false);
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			const checkWidth = () => setIsMobile(window.innerWidth < breakpoint);
+			checkWidth();
+			window.addEventListener('resize', checkWidth);
+			return () => window.removeEventListener('resize', checkWidth);
+		}
+	}, [breakpoint]);
+	return isMobile;
+}


### PR DESCRIPTION


<h2> <strong>Why</strong></h2>
<ul>
<li>
<p>桌機版使用直式 poster 導致背景圖片被壓縮變形。</p>
</li>
<li>
<p>小螢幕時文字貼近 Header、缺乏留白。</p>
</li>
<li>
<p>h1 標題過長時橫跨整個螢幕，視覺不平衡。</p>
</li>
</ul>
<hr>
<h2> <strong>Changes</strong></h2>

區塊 | 調整內容
-- | --
 RWD spacing | 新增 pt-[30vh]/md:pt-[40vh]/lg:h-[65vh]，確保小螢幕有留白空間
 圖片比例切換 | 新增 useIsMobile hook：手機顯示 poster、桌機顯示 backdrop
標題寬度限制 | 新增 max-w-[70%] → 50%，避免橫向過寬
 overview 長文處理 | 使用 line-clamp-3 限制顯示三行
 按鈕區改版 | Play / More Info 改為 Netflix 官方樣式，加入 hover & scale 動畫
ⓘ Info icon | 改為SVG，並微調 translate-y-[1px] 對齊文字中線
 背景層次 | 保留風格 gradient，確保與 Row 區自然銜接


<hr>
<h2> <strong>Additional Notes</strong></h2>
<ul>
<li>
<p><code inline="">useIsMobile</code> 為獨立 hook，可未來擴充 tablet、desktop breakpoint 判斷。</p>
</li>
<li>
<p>若需共用ⓘ Info icon，可後續抽出 <code inline="">/components/icons/CircleIIcon.tsx</code> 模組化使用。</p>
</li>
</ul>
<hr>
