### PR TITLE
feat(pages): scaffold /new /movies /mylist with SSG + ISR

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -55,11 +55,6 @@ function Header() {
 						</a>
 					</li>
 					<li>
-						<a className='headerLink' href='/tv'>
-							TV Shows
-						</a>
-					</li>
-					<li>
 						<a className='headerLink' href='/movies'>
 							Movies
 						</a>
@@ -69,6 +64,11 @@ function Header() {
 							New & Popular
 						</a>
 					</li>
+					{/* <li>
+						<a className='headerLink' href='/new'>
+							TV Shows
+						</a>
+					</li> */}
 					<li>
 						<a className='headerLink' href='/mylist'>
 							My List

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,11 +93,11 @@ const Home = ({
 	if (subscriptionError) {
 		return (
 			<div className='flex h-screen items-center justify-center bg-black'>
-				<div className='text-white text-center'>
-					<p className='text-red-500 mb-4'>{subscriptionError}</p>
+				<div className='text-center text-white'>
+					<p className='mb-4 text-red-500'>{subscriptionError}</p>
 					<button
 						onClick={() => window.location.reload()}
-						className='bg-[#e50914] px-4 py-2 rounded'
+						className='rounded bg-[#e50914] px-4 py-2'
 					>
 						重新載入
 					</button>
@@ -109,7 +109,7 @@ const Home = ({
 	if (!subscription) return <Plans products={products} />;
 
 	return (
-		<div className='relative bg-[linear-gradient(to_bottom,rgba(20,20,20,0)_0%,rgba(20,20,20,0.15)_15%,rgba(20,20,20,0.35)_29%,rgba(20,20,20,0.58)_44%,#141414_58%,#141414_100%)] rounded lg:h-[160vh] '>
+		<div className='relative rounded bg-[linear-gradient(to_bottom,rgba(20,20,20,0)_0%,rgba(20,20,20,0.15)_15%,rgba(20,20,20,0.35)_29%,rgba(20,20,20,0.58)_44%,#141414_58%,#141414_100%)] lg:h-[160vh]'>
 			<Head>
 				<title>Home - Netflixx</title>
 				<link rel='icon' href='/logo.svg' type='image/svg+xml' />
@@ -117,7 +117,7 @@ const Home = ({
 			</Head>
 
 			<Header />
-			<main className='relative pl-4 pb-24 space-y-24 lg:pl-16 '>
+			<main className='relative space-y-24 pb-24 pl-4 lg:pl-16'>
 				<Banner netflixOriginals={netflixOriginals} />
 
 				<section className='md:space-y-10'>

--- a/pages/movies.tsx
+++ b/pages/movies.tsx
@@ -1,0 +1,53 @@
+import Head from 'next/head';
+import Header from '@/components/Header';
+import Row from '@/components/Row';
+import Modal from '@/components/Modal';
+import requests from '@/utils/request';
+
+interface Props {
+  topRated: any[];
+  action: any[];
+  comedy: any[];
+}
+
+export default function MoviesPage({ topRated, action, comedy }: Props) {
+  return (
+    <div>
+      <Head>
+        <title>Movies</title>
+      </Head>
+      <Header />
+      <main className="pt-24 px-4 m-10">
+        <h1 className="mb-12 text-3xl font-bold">Movies</h1>
+        <section className="space-y-8">
+          <Row title="Top Rated" movies={topRated} orientation="poster" />
+          <Row title="Action Movies" movies={action} orientation="poster" />
+          <Row title="Comedies" movies={comedy} orientation="poster" />
+        </section>
+      </main>
+      <Modal />
+    </div>
+  );
+}
+
+export async function getStaticProps() {
+  try {
+    const [topRatedRes, actionRes, comedyRes] = await Promise.all([
+      fetch(requests.fetchTopRated).then((r) => r.json()),
+      fetch(requests.fetchActionMovies).then((r) => r.json()),
+      fetch(requests.fetchComedyMovies).then((r) => r.json()),
+    ]);
+
+    return {
+      props: {
+        topRated: topRatedRes.results || [],
+        action: actionRes.results || [],
+        comedy: comedyRes.results || [],
+      },
+      revalidate: 3600,
+    };
+  } catch (error) {
+    console.error('Error fetching movie data', error);
+    return { props: { topRated: [], action: [], comedy: [] }, revalidate: 60 };
+  }
+}

--- a/pages/mylist.tsx
+++ b/pages/mylist.tsx
@@ -1,0 +1,41 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import Header from '@/components/Header';
+import Modal from '@/components/Modal';
+import Row from '@/components/Row';
+import useAuth from '@/hooks/useAuth';
+import useList from '@/hooks/useList';
+
+export default function MyListPage() {
+	const router = useRouter();
+	const { user, loading } = useAuth();
+	const list = useList(user?.uid);
+
+	if (loading) return null;
+	if (!user) {
+		router.push('/login');
+		return null;
+	}
+
+	return (
+		<div>
+			<Head>
+				<title>My List</title>
+			</Head>
+			<Header />
+			<main className='m-10 px-4 pt-24'>
+				<h1 className='mb-6 text-3xl font-bold'>My List</h1>
+				{list.length === 0 ? (
+					<p className='text-gray-400'>
+						Your list is empty. Add movies to your list to see them here.
+					</p>
+				) : (
+					<section className='space-y-8'>
+						<Row title='' movies={list} orientation='poster' />
+					</section>
+				)}
+			</main>
+			<Modal />
+		</div>
+	);
+}

--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -1,0 +1,55 @@
+import Head from 'next/head';
+import Header from '@/components/Header';
+import Modal from '@/components/Modal';
+import Row from '@/components/Row';
+import requests from '@/utils/request';
+
+interface Props {
+	netflixOriginals: any[];
+	trending: any[];
+}
+
+export default function NewPage({ netflixOriginals, trending }: Props) {
+	return (
+		<div>
+			<Head>
+				<title>New & Popular</title>
+			</Head>
+			<Header />
+			<main className='m-10 px-4 pt-24'>
+				<h1 className='mb-10 text-3xl font-bold'>New & Popular</h1>
+				<section className='space-y-8'>
+					<Row title='New & Popular' movies={netflixOriginals} orientation='poster' />
+					<Row title='Trending Now' movies={trending} orientation='poster' />
+				</section>
+			</main>
+			<Modal />
+		</div>
+	);
+}
+
+export async function getStaticProps() {
+	try {
+		const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
+		const BASE = 'https://api.themoviedb.org/3';
+
+		const [netflixRes, trendingRes] = await Promise.all([
+			fetch(requests.fetchNetflixOriginals).then((r) => r.json()),
+			fetch(requests.fetchTrending).then((r) => r.json()),
+		]);
+
+		return {
+			props: {
+				netflixOriginals: netflixRes.results || [],
+				trending: trendingRes.results || [],
+			},
+			revalidate: 3600,
+		};
+	} catch (error) {
+		console.error('Error fetching TV data', error);
+		return {
+			props: { trending: [], topRated: [] },
+			revalidate: 60,
+		};
+	}
+}


### PR DESCRIPTION
### Why
- 為主要路徑新增對應的頁面，避免使用者空白頁面或 404
- 提升 SEO（SSG + ISR）
- /mylist 維持 client-side，保持與 Firestore 資料一致

### Changes
- 新增 pages/new.tsx（New & Popular）
- 新增 pages/movies.tsx
- 新增 pages/mylist.tsx（auth-guarded）
- TMDB 列表使用 SSG + ISR（revalidate: 3600）
- 透過 Header / Row / Thumbnail / Modal 保持 UI 一致性

### Notes
- dev-only console logs 尚未移除，將在後續清理 PR 處理
