### PR TITLE
fix(ui): refine header active states and poster loading/fallback behavior

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import { BellIcon, SearchIcon } from '@heroicons/react/solid';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import useAuth from '@/hooks/useAuth';
 import useSubscription from '@/hooks/useSubscription';
@@ -12,6 +13,7 @@ import BasicMenu from './BasicMenu';
 const SearchModal = dynamic(() => import('./SearchModal'), { ssr: false });
 
 function Header() {
+	const router = useRouter();
 	const [isScrolled, setIsScrolled] = useState(false);
 	const [hasNotifications, setHasNotifications] = useState(true);
 	const [showAccountMenu, setShowAccountMenu] = useState(false);
@@ -50,25 +52,41 @@ function Header() {
 
 				<ul className='hidden space-x-4 md:flex'>
 					<li>
-						<a className='headerLink' href='/'>
+						<Link
+							href='/'
+							className={`headerLink ${router.pathname === '/' ? 'headerLinkActive' : ''}`}
+							aria-current={router.pathname === '/' ? 'page' : undefined}
+						>
 							Home
-						</a>
+						</Link>
 					</li>
 					<li>
-						<a className='headerLink' href='/movies'>
+						<Link
+							href='/movies'
+							className={`headerLink ${router.pathname === '/movies' ? 'headerLinkActive' : ''}`}
+							aria-current={router.pathname === '/movies' ? 'page' : undefined}
+						>
 							Movies
-						</a>
+						</Link>
 					</li>
 					<li>
-						<a className='headerLink' href='/new'>
+						<Link
+							href='/new'
+							className={`headerLink ${router.pathname === '/new' ? 'headerLinkActive' : ''}`}
+							aria-current={router.pathname === '/new' ? 'page' : undefined}
+						>
 							New & Popular
-						</a>
+						</Link>
 					</li>
 
 					<li>
-						<a className='headerLink' href='/mylist'>
+						<Link
+							href='/mylist'
+							className={`headerLink ${router.pathname === '/mylist' ? 'headerLinkActive' : ''}`}
+							aria-current={router.pathname === '/mylist' ? 'page' : undefined}
+						>
 							My List
-						</a>
+						</Link>
 					</li>
 				</ul>
 			</div>

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -32,12 +32,12 @@ function Row({ title, movies, orientation = 'backdrop' }: Props) {
 
 	return (
 		<div className={containerClass}>
-			<h2 className='w-56 cursor-pointer text-sm font-semibold text-[#e5e5e5] transition duration-200 hover:text-white md:text-xl '>
+			<h2 className='w-56 cursor-pointer text-sm font-semibold text-[#e5e5e5] transition duration-200 hover:text-white md:text-xl'>
 				{title}
 			</h2>
 			<div className='group relative md:-ml-2'>
 				<ChevronLeftIcon
-					className={`absolute top-0 bottom-0 left-2 z-40 m-auto h-9 w-9 cursor-pointer opacity-0 transition hover:scale-125 group-hover:opacity-100 ${
+					className={`absolute bottom-0 left-2 top-0 z-40 m-auto h-9 w-9 cursor-pointer opacity-0 transition group-hover:opacity-100 hover:scale-125 ${
 						!isMoved && 'hidden'
 					}`}
 					onClick={() => handleClick('left')}
@@ -46,17 +46,27 @@ function Row({ title, movies, orientation = 'backdrop' }: Props) {
 					ref={rowRef}
 					className={
 						orientation === 'poster'
-							? 'flex scrollbar-hide items-center space-x-3 overflow-x-scroll md:space-x-5 md:p-3'
-							: 'flex scrollbar-hide items-center space-x-1 overflow-x-scroll md:space-x-3 md:p-2'
+							? 'flex items-center space-x-3 overflow-x-scroll scrollbar-hide md:space-x-5 md:p-3'
+							: 'flex items-center space-x-1 overflow-x-scroll scrollbar-hide md:space-x-3 md:p-2'
 					}
 					aria-label={`${title} row`}
 				>
-					{movies.map((movie) => (
-						<Thumbnail key={movie.id} movie={movie} orientation={orientation} />
-					))}
+					{movies && movies.length > 0
+						? movies.map((movie) => (
+								<Thumbnail key={movie.id} movie={movie} orientation={orientation} />
+							))
+						: // Show simple skeleton placeholders when there are no movies or data is loading/error
+							Array.from({ length: 6 }).map((_, i) => (
+								<div
+									key={`skeleton-${i}`}
+									className='relative h-40 min-w-[150px] overflow-hidden rounded-lg md:h-64 md:min-w-[220px]'
+								>
+									<div className='absolute inset-0 animate-pulse bg-gradient-to-r from-gray-700 via-gray-600 to-gray-700' />
+								</div>
+							))}
 				</div>
 				<ChevronRightIcon
-					className='absolute top-0 bottom-0 right-2 z-40 m-auto h-9 w-9 cursor-pointer opacity-0 transition hover:scale-125 group-hover:opacity-100'
+					className='absolute bottom-0 right-2 top-0 z-40 m-auto h-9 w-9 cursor-pointer opacity-0 transition group-hover:opacity-100 hover:scale-125'
 					onClick={() => handleClick('right')}
 				/>
 			</div>

--- a/components/Thumbnail.tsx
+++ b/components/Thumbnail.tsx
@@ -18,6 +18,7 @@ function Thumbnail({ movie, orientation = 'backdrop', tallOnLarge = false }: Pro
 	const [, setShowModal] = useRecoilState(modalState);
 	const [, setCurrentMovie] = useRecoilState(movieState);
 	const [imageError, setImageError] = useState(false);
+	const [isLoaded, setIsLoaded] = useState(false);
 	// choose poster for portrait, otherwise backdrop
 	const imagePath =
 		orientation === 'poster'
@@ -40,6 +41,10 @@ function Thumbnail({ movie, orientation = 'backdrop', tallOnLarge = false }: Pro
 				setShowModal(true);
 			}}
 		>
+			{/* Skeleton while image loads */}
+			{!isLoaded && !imageError && (
+				<div className='absolute inset-0 animate-pulse bg-gradient-to-r from-gray-700 via-gray-600 to-gray-700' />
+			)}
 			<Image
 				src={
 					imageError || !imagePath
@@ -47,18 +52,26 @@ function Thumbnail({ movie, orientation = 'backdrop', tallOnLarge = false }: Pro
 						: `https://image.tmdb.org/t/p/w500${imagePath}`
 				}
 				alt={movie.title || movie.name || 'Movie poster'}
-				className='rounded-sm object-cover md:rounded'
+				className={`rounded-sm object-cover transition-opacity duration-300 md:rounded ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
 				fill={true}
 				sizes={
 					orientation === 'poster'
 						? '(max-width: 768px) 40vw, (max-width: 1200px) 20vw, 12vw'
 						: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
 				}
+				onLoadingComplete={() => setIsLoaded(true)}
 				onError={() => {
 					console.error(`Failed to load image for movie: ${movie.title || movie.name}`, imagePath);
 					setImageError(true);
+					setIsLoaded(true);
 				}}
 			/>
+			{/* Error overlay */}
+			{imageError && (
+				<div className='absolute inset-0 flex items-center justify-center bg-black/60 p-2 text-center'>
+					<span className='text-sm text-gray-300'>Image unavailable</span>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/pages/movies.tsx
+++ b/pages/movies.tsx
@@ -1,53 +1,52 @@
 import Head from 'next/head';
 import Header from '@/components/Header';
-import Row from '@/components/Row';
 import Modal from '@/components/Modal';
+import Row from '@/components/Row';
 import requests from '@/utils/request';
 
 interface Props {
-  topRated: any[];
-  action: any[];
-  comedy: any[];
+	topRated: any[];
+	action: any[];
+	comedy: any[];
 }
 
 export default function MoviesPage({ topRated, action, comedy }: Props) {
-  return (
-    <div>
-      <Head>
-        <title>Movies</title>
-      </Head>
-      <Header />
-      <main className="pt-24 px-4 m-10">
-        <h1 className="mb-12 text-3xl font-bold">Movies</h1>
-        <section className="space-y-8">
-          <Row title="Top Rated" movies={topRated} orientation="poster" />
-          <Row title="Action Movies" movies={action} orientation="poster" />
-          <Row title="Comedies" movies={comedy} orientation="poster" />
-        </section>
-      </main>
-      <Modal />
-    </div>
-  );
+	return (
+		<div>
+			<Head>
+				<title>Movies</title>
+			</Head>
+			<Header />
+			<main className='m-10 px-4 pt-24'>
+				<section className='space-y-8'>
+					<Row title='Top Rated' movies={topRated} orientation='poster' />
+					<Row title='Action Movies' movies={action} orientation='poster' />
+					<Row title='Comedies' movies={comedy} orientation='poster' />
+				</section>
+			</main>
+			<Modal />
+		</div>
+	);
 }
 
 export async function getStaticProps() {
-  try {
-    const [topRatedRes, actionRes, comedyRes] = await Promise.all([
-      fetch(requests.fetchTopRated).then((r) => r.json()),
-      fetch(requests.fetchActionMovies).then((r) => r.json()),
-      fetch(requests.fetchComedyMovies).then((r) => r.json()),
-    ]);
+	try {
+		const [topRatedRes, actionRes, comedyRes] = await Promise.all([
+			fetch(requests.fetchTopRated).then((r) => r.json()),
+			fetch(requests.fetchActionMovies).then((r) => r.json()),
+			fetch(requests.fetchComedyMovies).then((r) => r.json()),
+		]);
 
-    return {
-      props: {
-        topRated: topRatedRes.results || [],
-        action: actionRes.results || [],
-        comedy: comedyRes.results || [],
-      },
-      revalidate: 3600,
-    };
-  } catch (error) {
-    console.error('Error fetching movie data', error);
-    return { props: { topRated: [], action: [], comedy: [] }, revalidate: 60 };
-  }
+		return {
+			props: {
+				topRated: topRatedRes.results || [],
+				action: actionRes.results || [],
+				comedy: comedyRes.results || [],
+			},
+			revalidate: 3600,
+		};
+	} catch (error) {
+		console.error('Error fetching movie data', error);
+		return { props: { topRated: [], action: [], comedy: [] }, revalidate: 60 };
+	}
 }

--- a/pages/mylist.tsx
+++ b/pages/mylist.tsx
@@ -24,7 +24,7 @@ export default function MyListPage() {
 			</Head>
 			<Header />
 			<main className='m-10 px-4 pt-24'>
-				<h1 className='mb-6 text-3xl font-bold'>My List</h1>
+				<p className='mb-1 ml-1 text-xl font-bold'>My List</p>
 				{list.length === 0 ? (
 					<p className='text-gray-400'>
 						Your list is empty. Add movies to your list to see them here.

--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -17,7 +17,6 @@ export default function NewPage({ netflixOriginals, trending }: Props) {
 			</Head>
 			<Header />
 			<main className='m-10 px-4 pt-24'>
-				<h1 className='mb-10 text-3xl font-bold'>New & Popular</h1>
 				<section className='space-y-8'>
 					<Row title='New & Popular' movies={netflixOriginals} orientation='poster' />
 					<Row title='Trending Now' movies={trending} orientation='poster' />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -41,6 +41,10 @@
 	.headerLink {
 		@apply cursor-pointer text-lg font-light text-[#e5e5e5] transition duration-[.4s] hover:text-[#b3b3b3];
 	}
+
+	.headerLinkActive {
+		@apply font-semibold text-white underline decoration-[#e50914] decoration-2 underline-offset-4;
+	}
 	.bannerButton {
 		@apply flex items-center gap-x-2 rounded px-5 py-1.5 text-sm font-semibold transition hover:opacity-75 md:px-8 md:py-2.5 md:text-xl;
 	}


### PR DESCRIPTION


## **概述**

本次 PR 修正 Header 導覽狀態與圖片載入行為，確保各頁面的互動、可及性（a11y）與視覺呈現一致。

---

## **變更內容**

* 啟用並驗證導覽列 active 狀態（Home / Movies / New & Popular / My List）
* 套用正確的 `aria-current` 標記，提高導覽可及性
* 確認海報載入動畫（fade-in / skeleton）正常運作
* 驗證破圖 fallback overlay（"Image unavailable"）能正確顯示

---

## **影響範圍**

* Header 導覽列
* Row / Thumbnail 的圖片載入與錯誤處理
* Home、Movies、New、My List 等內容頁的整體視覺一致性

---


## **測試項目**


* 滑動 / 捲動後 Header 變化（背景、active 狀態）
* 圖片載入、延遲載入與 fallback
* 點擊 Thumbnail 開啟 Modal 的行為
* 在不同路由之間切換時 active 狀態是否同步更新

## **沒有破壞性改動（Non-breaking）**

> 此 PR 不影響既有功能，僅針對 UI 表現與可及性進行修正。

