### PR TITLE
chore(lint): update ESLint and Prettier rules for consistent formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,16 +9,17 @@
 		"plugin:react/recommended",
 		"plugin:react-hooks/recommended",
 		"plugin:import/recommended",
-		"plugin:import/typescript",
-		"plugin:prettier/recommended" 
+		"plugin:import/typescript"
 	],
 	"rules": {
-		"import/order": "off", // 禁用 ESLint 的 import 排序，改用 Prettier 處理
+		"import/order": "off",
 		"import/newline-after-import": "error",
 		"import/no-duplicates": "error",
 		"@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
 		"react/react-in-jsx-scope": "off",
-		"react/prop-types": "off"
+		"react/prop-types": "off",
+
+		"prettier/prettier": "off" // ⭐ 關閉 Prettier rule（必要）
 	},
 	"settings": {
 		"react": {


### PR DESCRIPTION
## 為什麼（Why）

原本 ESLint 與 Prettier 的規則重複定義，且有部份設定彼此衝突（例如 import/order、prettier/prettier）。
另外也存在冗餘規則，造成編輯器反覆自動修正、或 VSCode 顯示警告。

## 做了什麼（What Changed）

- 關閉 import/order（改由 Prettier 處理）

- 移除多餘或重複的規則

- 關閉 prettier/prettier 以避免與 Prettier 插件衝突

- 保持 React / TypeScript 規則一致性

## 影響（Impact）

- 開發時不會再遇到 ESLint / Prettier 互相打架

- import 排序統一由 Prettier 處理

- linter 訊息更乾淨、更準確