### PR TITLE
style(header): adjust responsive padding for improved layout spacing

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,7 +31,7 @@
 	}
 
 	header {
-		@apply fixed top-0 z-50 flex w-full justify-between px-4 py-4 transition-all lg:px-10 lg:py-6;
+		@apply fixed top-0 z-50 flex w-full justify-between px-4 py-4 transition-all lg:px-16 lg:py-4;
 	}
 }
 


### PR DESCRIPTION
### Why

- Header 在大型螢幕上（lg breakpoint）左右間距不一致，造成視覺上壓縮且與其他版面 spacing 不對齊。

## #What Changed

- 將 lg:px-10 改為 lg:px-16
- 將 lg:py-6 微調為 lg:py-4
- 保持 mobile 與 default breakpoint 不變

## Impact

- Header 在 desktop 上的左右留白更舒適
- 與其他 section spacing 更一致
- 不影響手機版樣式