### PR TITLE
docs(env): update .env.example with TMDB API keys and Stripe config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
-# TMDB API 配置
+# TMDB API 設置
+NEXT_PUBLIC_TMDB_API_KEY=your_tmdb_api_key_here
+# 可選：向下相容的舊名稱（未設定時會使用 TMDB_API_KEY）
 NEXT_PUBLIC_API_KEY=your_tmdb_api_key_here
 
-# Stripe 配置
+# Stripe 設置
 STRIPE_SECRET_KEY=your_stripe_secret_key_here


### PR DESCRIPTION
## 為什麼（Why）

本專案新增了 tmdbFetch，使用 NEXT_PUBLIC_TMDB_API_KEY 作為主要 key。
需要在 env template 補上新的 key 與備註，避免誤用舊 key。

## 做了什麼（What Changed）

- 新增 NEXT_PUBLIC_TMDB_API_KEY（主要 key）
- 保留舊的 NEXT_PUBLIC_API_KEY 作為 fallback（相容舊版本）
- 調整 Stripe config 區塊格式
- 新增註解更容易理解用途

## 影響（Impact）

- 新開發者能更快理解要填的 key
-不會因為漏填 TMDB key 而 build 失敗
- 環境變數文件更一致、更好閱讀