### PR TITLE
fix(auth): remove redirect race + centralize auth error handling

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,7 +86,6 @@ const Home = ({
 	}
 
 	if (!user) {
-		router.push('/login');
 		return null;
 	}
 
@@ -180,14 +179,20 @@ export const getStaticProps = async () => {
 			romanceMoviesRes,
 			documentariesRes,
 		] = await Promise.all([
-			tmdbFetch<TmdbResponse<Movie>>(requests.fetchNetflixOriginals, { params: { language: 'en-US' } }),
+			tmdbFetch<TmdbResponse<Movie>>(requests.fetchNetflixOriginals, {
+				params: { language: 'en-US' },
+			}),
 			tmdbFetch<TmdbResponse<Movie>>(requests.fetchTrending, { params: { language: 'en-US' } }),
 			tmdbFetch<TmdbResponse<Movie>>(requests.fetchTopRated, { params: { language: 'en-US' } }),
 			tmdbFetch<TmdbResponse<Movie>>(requests.fetchActionMovies, { params: { language: 'en-US' } }),
 			tmdbFetch<TmdbResponse<Movie>>(requests.fetchComedyMovies, { params: { language: 'en-US' } }),
 			tmdbFetch<TmdbResponse<Movie>>(requests.fetchHorrorMovies, { params: { language: 'en-US' } }),
-			tmdbFetch<TmdbResponse<Movie>>(requests.fetchRomanceMovies, { params: { language: 'en-US' } }),
-			tmdbFetch<TmdbResponse<Movie>>(requests.fetchDocumentaries, { params: { language: 'en-US' } }),
+			tmdbFetch<TmdbResponse<Movie>>(requests.fetchRomanceMovies, {
+				params: { language: 'en-US' },
+			}),
+			tmdbFetch<TmdbResponse<Movie>>(requests.fetchDocumentaries, {
+				params: { language: 'en-US' },
+			}),
 		]);
 
 		return {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -6,11 +6,6 @@ import { SubmitHandler } from 'react-hook-form';
 import AuthForm from '@/components/AuthForm';
 import useAuth from '@/hooks/useAuth';
 
-interface FirebaseAuthError {
-	code: string;
-	message: string;
-}
-
 type Inputs = {
 	email: string;
 	password: string;
@@ -18,28 +13,10 @@ type Inputs = {
 
 function Login() {
 	const router = useRouter();
-	const { signIn, loading } = useAuth();
-	const [message, setMessage] = useState({ type: '', content: '' });
+	const { signIn, loading, initialLoading } = useAuth();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	// form is handled by shared AuthForm component
-
-	// 統一的錯誤處理函數
-	const handleAuthError = (error: FirebaseAuthError) => {
-		switch (error.code) {
-			case 'auth/email-already-in-use':
-				return { type: 'error', content: '此信箱已被註冊，請直接登入' };
-			case 'auth/user-not-found':
-				return { type: 'error', content: '帳號未註冊，請先註冊帳號' };
-			case 'auth/wrong-password':
-				return { type: 'error', content: '密碼錯誤，請重新輸入' };
-			case 'auth/invalid-email':
-				return { type: 'error', content: '信箱格式不正確' };
-			default:
-				console.error('認證錯誤:', error);
-				return { type: 'error', content: '發生錯誤，請稍後再試' };
-		}
-	};
 
 	// adapter to pass to AuthForm (react-hook-form types -> simple function)
 	const handleAuthFormSubmit = async (data: Inputs) => {
@@ -49,19 +26,12 @@ function Login() {
 	const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
 		if (isSubmitting) return;
 		setIsSubmitting(true);
-		setMessage({ type: '', content: '' });
 
 		try {
 			const result = await signIn(email, password);
 			if (result.success) {
 				router.push('/');
-				setMessage({ type: 'success', content: '登入成功！即將跳轉...' });
-			} else {
-				setMessage(handleAuthError({ code: result.error || '', message: '' }));
 			}
-		} catch (error) {
-			const firebaseError = error as FirebaseAuthError;
-			setMessage(handleAuthError(firebaseError));
 		} finally {
 			setIsSubmitting(false); // 確保在操作完成後重置狀態
 		}
@@ -93,7 +63,7 @@ function Login() {
 				sizes='75px'
 			/>
 
-			<AuthForm mode='login' onSubmit={handleAuthFormSubmit} loading={loading} message={message} />
+			<AuthForm mode='login' onSubmit={handleAuthFormSubmit} loading={loading || isSubmitting || initialLoading} />
 
 			<div className='mt-6 text-[gray] text-center'>
 				尚未加入Netflixx? {'  '}

--- a/pages/mylist.tsx
+++ b/pages/mylist.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 import Header from '@/components/Header';
 import Modal from '@/components/Modal';
 import Row from '@/components/Row';
@@ -7,15 +6,10 @@ import useAuth from '@/hooks/useAuth';
 import useList from '@/hooks/useList';
 
 export default function MyListPage() {
-	const router = useRouter();
-	const { user, loading } = useAuth();
-	const list = useList(user?.uid);
+ const { user, loading } = useAuth();
+ const list = useList(user?.uid);
 
-	if (loading) return null;
-	if (!user) {
-		router.push('/login');
-		return null;
-	}
+ if (loading || !user) return null;
 
 	return (
 		<div>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -6,11 +6,6 @@ import { SubmitHandler } from 'react-hook-form';
 import AuthForm from '@/components/AuthForm';
 import useAuth from '@/hooks/useAuth';
 
-interface FirebaseAuthError {
-	code: string;
-	message: string;
-}
-
 type Inputs = {
 	email: string;
 	password: string;
@@ -18,43 +13,18 @@ type Inputs = {
 
 function Signup() {
 	const router = useRouter();
-	const { signUp, loading } = useAuth();
-	const [message, setMessage] = useState({ type: '', content: '' });
+	const { signUp, loading, initialLoading } = useAuth();
 	const [isSubmitting, setIsSubmitting] = useState(false);
-
-	// form handled by shared AuthForm component
-	const handleAuthError = (error: FirebaseAuthError) => {
-		switch (error.code) {
-			case 'auth/email-already-in-use':
-				return { type: 'error', content: '此信箱已被註冊，請直接登入' };
-			case 'auth/user-not-found':
-				return { type: 'error', content: '帳號未註冊，請先註冊帳號' };
-			case 'auth/wrong-password':
-				return { type: 'error', content: '密碼錯誤，請重新輸入' };
-			case 'auth/invalid-email':
-				return { type: 'error', content: '信箱格式不正確' };
-			default:
-				console.error('認證錯誤:', error);
-				return { type: 'error', content: '發生錯誤，請稍後再試' };
-		}
-	};
 
 	const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
 		if (isSubmitting) return;
 		setIsSubmitting(true);
-		setMessage({ type: '', content: '' });
 
 		try {
 			const result = await signUp(email, password);
 			if (result.success) {
-				setMessage({ type: 'success', content: '註冊成功！即將跳轉...' });
-				setTimeout(() => router.push('/'), 1500);
-			} else {
-				setMessage(handleAuthError({ code: result.error || '', message: '' }));
+				router.push('/');
 			}
-		} catch (error) {
-			const firebaseError = error as FirebaseAuthError;
-			setMessage(handleAuthError(firebaseError));
 		} finally {
 			setIsSubmitting(false);
 		}
@@ -90,7 +60,11 @@ function Signup() {
 				sizes='75px'
 			/>
 
-			<AuthForm mode='signup' onSubmit={handleAuthFormSubmit} loading={loading} message={message} />
+			<AuthForm
+				mode='signup'
+				onSubmit={handleAuthFormSubmit}
+				loading={loading || isSubmitting || initialLoading}
+			/>
 
 			<div className='mt-6 text-center text-[gray]'>
 				已經有帳號? {'  '}


### PR DESCRIPTION
本 PR 主要重構 Auth Flow，以解決：

- 首頁與 MyList 的雙重 redirect 導致的 **fetch abort / Navigation aborted**
- 登入 / 註冊錯誤分散在三個地方（頁面層、AuthForm、useAuth）
- useAuth 未將錯誤寫入 state，導致 UI 永遠不會顯示錯誤
- AuthForm 邏輯過重、頁面層處理錯誤過多
- 自動登出 Timer 依賴 logout callback，可能造成重複初始化

###  重構目標

讓 Auth 流程：

- **redirect → 單一來源（useAuth）**
- **錯誤 → 單一來源（useAuth.error）**
- **頁面層 → 單純觸發行為，不再 decode Firebase error**
- **AuthForm → 純 UI Component，不含邏輯**

全部行為集中、行為一致、可維護性提升。


---

#  **Commits Included**

### **Commit 1**

```
fix(auth-redirect): remove duplicate login redirects to prevent abort errors

```

Changes:

- `pages/index.tsx` → 未登入時只 return null，不再 router.push。
- `pages/mylist.tsx` → 同上。
- redirect 完全由 `useAuth` 控制。
- 修復 Navigation aborted / fetch abort 警告。

### **Commit 2**

```
refactor(auth-error): centralize auth errors in useAuth and simplify UI consumption

```

Changes:

- `useAuth.tsx` → setError/resetError、全域錯誤狀態、修正 memo & timer。
- `AuthForm.tsx` → 使用 useAuth.error、移除 message prop、加入 ERROR_MAP。
- `login.tsx` / `signup.tsx` → 移除 message / Firebase error decoding。
- 簡化 loading handle。

---

#  **Before / After（差異摘要）**

###  Before

- 頁面層 + useAuth 都在 redirect → 競爭、跳兩次
- useAuth 沒有 setError → UI 永遠不會顯示登入錯誤
- Login/Signup 要自己 decode Firebase error
- AuthForm 需要傳入 message prop（邏輯過重）
- Timer 依賴 logout → 無限 re-init 風險
- Auth State 不一致

### After

- redirect 100% 由 useAuth 控制 → 乾淨且可預測
- useAuth.error → 單一錯誤來源
- Login/Signup 不再 decode error → 單純 submit
- AuthForm → 純 UI（統一讀取 useAuth.error）
- Timer 依賴 user → 稳定且無副作用
- 整體 Auth Flow 更一致、易維護

---

#  **Detailed Changes**

##  useAuth.tsx

- 增加 `setError`, `resetError`
- 修正 memo dependencies
- 使用 frozen PUBLIC_PATHS
- redirect 控制集中於 onAuthStateChanged
- auto logout timer 改為只依賴 user
- 移除可能造成 infinite loop 的 logout deps

##  AuthForm.tsx

- 移除 message props
- 統一錯誤來源來自 useAuth.error
- 使用 ERROR_MAP 映射 Firebase 錯誤碼
- 提升可讀性與可維護性
- Form component 變成純 UI 元件

##  Login.tsx / Signup.tsx

- 移除所有本地錯誤、message state
- 移除 handleAuthError（已不需要）
- loading 整合 useAuth.loading + isSubmitting
- 成功後才 redirect

##  pages/index.tsx / pages/mylist.tsx

- 移除 router.push('/login')
- 改為 `if (!user) return null;`
- 修復重導競爭條件

---

#  **Risk / Regression Concerns**

- Login/Signup UI 完全依賴 useAuth.error
- redirect 行為集中 → 需要完整測試
- auto logout 改由 user 控制 → 應測試 30 分鐘後的邏輯
- initialLoading 行為改變 → 頁面渲染需確認

---

#  **Test Plan**

- [ ]  未登入進入 `/` → 自動跳轉 `/login`（無 abort）
- [ ]  未登入進 `/mylist` → 自動跳轉 `/login`（無 abort）
- [ ]  帳號不存在 → 正確顯示「帳號未註冊」
- [ ]  密碼錯誤 → 正確顯示「密碼錯誤」
- [ ]  Email 已存在 → 正確顯示「此信箱已被註冊」
- [ ]  登入成功 → redirect `/`
- [ ]  自動登出（30 分鐘）會正確跳轉 `/login`
- [ ]  AuthForm 不再依賴 message prop
- [ ]  Login / Signup 中沒有 duplicated error handling

---

#  **Rollback Strategy**

1. 將 useAuth.tsx 還原
2. 還原 AuthForm（重新加入 message prop）
3. 還原 Login/Signup 的 local error handling
4. revert PR 即可恢復所有功能

→ **純前端邏輯，回滾安全且立即生效。**

---

#  Reviewer Notes

- 若看到仍有 ESLint warnings：
    
    是舊檔頁面（movies/new/search/header/thumbnail），不在本 PR 範圍內。
    
- 此 PR 僅專注在 Auth Flow，不會破壞主功能。
- 若要測試 timer，改成 10 秒即可更容易驗證。