### PR TITLE
Refactor/& perf  eliminate over rendering via strict state ownership

### DIFF
--- a/components/Thumbnail.tsx
+++ b/components/Thumbnail.tsx
@@ -1,6 +1,6 @@
 import { DocumentData } from 'firebase/firestore';
 import Image from 'next/image';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { useState } from 'react';
 import { modalState, movieState } from '@/atoms/modalAtom';
 import { Movie } from '@/typings';
@@ -13,10 +13,10 @@ interface Props {
 }
 
 function Thumbnail({ movie, orientation = 'backdrop', tallOnLarge = false }: Props) {
-	// These state variables are used by parent/sibling components through Recoil
-	// we only need the setters here; discard the first element to avoid unused var lint
-	const [, setShowModal] = useRecoilState(modalState);
-	const [, setCurrentMovie] = useRecoilState(movieState);
+	// We only need to set the state, not read it.
+	// using useSetRecoilState prevents all Thumbnails from re-rendering when the state changes!
+	const setShowModal = useSetRecoilState(modalState);
+	const setCurrentMovie = useSetRecoilState(movieState);
 	const [imageError, setImageError] = useState(false);
 	const [isLoaded, setIsLoaded] = useState(false);
 	// choose poster for portrait, otherwise backdrop

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,6 @@ import Row from '@/components/Row';
 import useAuth from '@/hooks/useAuth';
 import useList from '@/hooks/useList';
 import useSubscription from '@/hooks/useSubscription';
-import { modalState } from '@/atoms/modalAtom';
 import { db } from '@/firebase';
 import { Movie } from '@/typings';
 import requests, { tmdbFetch, TmdbResponse } from '@/utils/request';
@@ -50,7 +49,6 @@ const Home = ({
 		loading: subscriptionLoading,
 		error: subscriptionError,
 	} = useSubscription(user);
-	const showModal = useRecoilValue(modalState);
 	const list = useList(user?.uid);
 
 	useEffect(() => {
@@ -131,7 +129,7 @@ const Home = ({
 				</section>
 			</main>
 
-			{showModal && <Modal />}
+			<Modal />
 			<Footer />
 		</div>
 	);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -15,7 +15,6 @@ type Inputs = {
 function Login() {
 	const router = useRouter();
 	const { signIn, loading, initialLoading } = useAuth();
-	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	// form is handled by shared AuthForm component
 
@@ -25,16 +24,11 @@ function Login() {
 	};
 
 	const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
-		if (isSubmitting) return;
-		setIsSubmitting(true);
+		if (loading) return;
 
-		try {
-			const result = await signIn(email, password);
-			if (result.success) {
-				router.push('/');
-			}
-		} finally {
-			setIsSubmitting(false); // 確保在操作完成後重置狀態
+		const result = await signIn(email, password);
+		if (result.success) {
+			router.push('/');
 		}
 	};
 
@@ -79,7 +73,7 @@ function Login() {
 				<AuthForm
 					mode='login'
 					onSubmit={handleAuthFormSubmit}
-					loading={loading || isSubmitting || initialLoading}
+					loading={loading || initialLoading}
 				/>
 
 				<div className='mt-6 text-center text-[gray]'>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -15,19 +15,13 @@ type Inputs = {
 function Signup() {
 	const router = useRouter();
 	const { signUp, loading, initialLoading } = useAuth();
-	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
-		if (isSubmitting) return;
-		setIsSubmitting(true);
+		if (loading) return;
 
-		try {
-			const result = await signUp(email, password);
-			if (result.success) {
-				router.push('/');
-			}
-		} finally {
-			setIsSubmitting(false);
+		const result = await signUp(email, password);
+		if (result.success) {
+			router.push('/');
 		}
 	};
 
@@ -74,7 +68,7 @@ function Signup() {
 				<AuthForm
 					mode='signup'
 					onSubmit={handleAuthFormSubmit}
-					loading={loading || isSubmitting || initialLoading}
+					loading={loading || initialLoading}
 				/>
 
 				<div className='mt-6 text-center text-[gray]'>


### PR DESCRIPTION
##  Summary
This PR resolves a series of over-rendering issues caused by imprecise state ownership and 
redundant subscriptions, verified through React DevTools Profiler flamegraphs. All changes 
adhere to a single guiding principle:
**only the component that needs to read a state should subscribe to it.**

##  Changes

### 1. `refactor(auth)` — `pages/login.tsx`, `pages/signup.tsx`
- **Problem**: Local `isSubmitting` and Context `loading` updated simultaneously on form submit, 
  causing overlapping `Hook changed` + `Context changed` double renders.
- **Fix**: Removed `isSubmitting`. Delegated all loading state to `useAuth` as Single Source of Truth.

### 2. `refactor(home)` — `pages/index.tsx`
- **Problem**: `Home` subscribed to `modalState` via `useRecoilValue`, forcing the entire page 
  and all nested `<Row>` lists to re-render every time a thumbnail was clicked.
- **Fix**: Removed `useRecoilValue(modalState)`. `<Modal />` now renders unconditionally and 
  manages its own open state autonomously via Recoil.

### 3. `perf(components)` — `components/Thumbnail.tsx`
- **Problem**: `useRecoilState(modalState)` registered all `<Thumbnail />` instances as subscribers, 
  despite only needing the setter — triggering an O(N) re-render cascade across every visible thumbnail.
- **Fix**: Replaced `useRecoilState` with `useSetRecoilState`. Components that only write to 
  state should never subscribe to it.


##  Profiler Verification
All changes validated using React DevTools Profiler:
- **Auth pages**: Single-source render cycle — no overlapping commits.
- **Home page**: `Home` and all `Row` components grayed out (did not render) during modal interactions.  
- **Thumbnails**: Only the clicked `<Thumbnail />` and `<Modal />` render on interaction — **O(1) confirmed**.
