### PR TITLE
docs: add personal website and contact info to project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ Six years in procurement trained a sharp instinct for **risk anticipation** and 
 
 This project is the concrete expression of that approach: the three-state planning behind every image component, the abort logic on every `AbortSignal`, and the cache layer on every Promise chain — each reflects a core question I keep asking: _when the system is imperfect, how do we guarantee UI consistency?_
 
+- **Website**: [tinahu.dev](https://www.tinahu.dev/)
 - **GitHub**: [yuting813](https://github.com/yuting813)
+- **Email**: [tinahuu321@gmail.com](mailto:tinahuu321@gmail.com)
 
 > **Educational Disclaimer**
 > This project is for personal technical demonstration and educational purposes only. It is **not** a commercial product. All movie data is sourced from the [TMDB API](https://www.themoviedb.org/).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -164,7 +164,9 @@ utils/          # API 轉發介面與網路層防禦實作
 
 這個專案正是這種思維的具象化：每一個元件的三態規劃、每一條 AbortSignal 的中斷邏輯，以及每一層 Promise 請求的緩存，都體現了我對於「當系統不完美時，我們如何保證 UI 一致性」的深度考量。
 
+- **Website**: [tinahu.dev](https://www.tinahu.dev/)
 - **GitHub**: [yuting813](https://github.com/yuting813)
+- **Email**: [tinahuu321@gmail.com](mailto:tinahuu321@gmail.com)
 
 > **教育用途免責聲明**
 > 本專案僅供個人技術證明與教育用途，**非**商業產品，且與任何串流媒體服務無關。電影資料皆來自 [TMDB API](https://www.themoviedb.org/)


### PR DESCRIPTION
## Summary
Updated project documentation to include professional contact information and a link to my personal portfolio website.

## Changes
- Added personal website link: `https://www.tinahu.dev/`
- Added contact email: `tinahuu321@gmail.com`
- Updated both English and Traditional Chinese README files for consistency.

## Rationale
Providing a direct link to my portfolio website allows recruiters to see a comprehensive view of my technical projects and professional background, facilitating a smoother evaluation process.