### PR TITLE
refactor(header): remove unimplemented feature placeholders to prevent misleading code review

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { BellIcon, SearchIcon } from '@heroicons/react/solid';
+import { SearchIcon } from '@heroicons/react/solid';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -15,7 +15,6 @@ const SearchModal = dynamic(() => import('./SearchModal'), { ssr: false });
 function Header() {
 	const router = useRouter();
 	const [isScrolled, setIsScrolled] = useState(false);
-	const [hasNotifications] = useState(true);
 	const [showAccountMenu, setShowAccountMenu] = useState(false);
 	const { logout, user } = useAuth();
 	const { subscription } = useSubscription(user ?? null);
@@ -100,29 +99,6 @@ function Header() {
 					<SearchIcon className='h-7 w-7' />
 				</button>
 				<SearchModal open={showSearchModal} onClose={() => setShowSearchModal(false)} />
-
-				<button aria-label='Kids' className='iconButton hidden lg:inline-flex' title='Kids section'>
-					<span className='text-base'>Kids</span>
-				</button>
-
-				<button
-					aria-label='Notifications'
-					className='iconButton relative'
-					onClick={() => {
-						if (process.env.NODE_ENV !== 'production') {
-							console.log('Notifications clicked');
-						}
-					}}
-					title='View notifications'
-				>
-					<BellIcon className='h-6 w-6' />
-					{hasNotifications && (
-						<span
-							className='absolute -right-0 -top-0 inline-flex h-3 w-3 items-center justify-center rounded-full bg-red-600'
-							aria-hidden='true'
-						/>
-					)}
-				</button>
 
 				<div className='relative pl-2'>
 					<button


### PR DESCRIPTION
### Problem
`Header.tsx` contained two UI elements that appeared functional but were never implemented:

- **Kids button**: Rendered as `<button>` with no `onClick` — clicking produces zero effect.
- **Notifications bell**: `onClick` triggers only `console.log()` in dev; the red badge dot is driven by `hasNotifications = useState(true)` (hardcoded, not connected to any data source).

These placeholders create a false signal during code review: a reviewer unfamiliar with the codebase would reasonably assume these features exist. In an interview context, this is especially problematic — it looks like unfinished work rather than intentional scope decisions.

### Decision
Remove both elements entirely rather than leaving them as stubs.

**Trade-off considered**: Removing these slightly reduces visual parity with the original Netflix UI. The alternative (leaving them in with a comment) was rejected because dead code with comments still misleads — it invites questions like "why isn't this wired up?" without a clear answer.

### Changes
- `Header.tsx`: Remove Kids `<button>`, Notifications `<button>`, `hasNotifications` state
- `Header.tsx`: Remove now-unused `BellIcon` import (ESLint `no-unused-vars` would have flagged this)
