### PR TITLE
refactor: remove legacy NEXT_PUBLIC_API_KEY fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 # TMDB API 設置
 NEXT_PUBLIC_TMDB_API_KEY=your_tmdb_api_key_here
-# 向下相容的舊名稱 (utils/request.ts 使用)
-NEXT_PUBLIC_API_KEY=your_tmdb_api_key_here
 
 # Firebase 設置 (前端可見，用於 firebase.ts)
 NEXT_PUBLIC_FIREBASE_API_KEY=your_firebase_api_key_here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           NEXT_PUBLIC_IS_CI: "true"
           NEXT_PUBLIC_TMDB_API_KEY: "mock-tmdb-key"
-          NEXT_PUBLIC_API_KEY: "mock-tmdb-key"
           NEXT_PUBLIC_FIREBASE_API_KEY: "mock-firebase-key"
           NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "mock.firebaseapp.com"
           NEXT_PUBLIC_FIREBASE_PROJECT_ID: "mock-project-id"

--- a/utils/request.ts
+++ b/utils/request.ts
@@ -1,8 +1,6 @@
 // 1. ENV configuration
 //-------------------------------------------------------------
-const ENV_API_KEY =
-	(process.env.NEXT_PUBLIC_TMDB_API_KEY || process.env.NEXT_PUBLIC_API_KEY || '').trim() ||
-	undefined;
+const ENV_API_KEY = process.env.NEXT_PUBLIC_TMDB_API_KEY?.trim() || undefined;
 
 const BASE_URL = 'https://api.themoviedb.org/3';
 


### PR DESCRIPTION
## Summary
Remove the legacy `NEXT_PUBLIC_API_KEY` environment variable, which was the original TMDB key name before the TMDB centralization refactor (`3ac4b81`).

## Background
During `refactor(tmdb): centralize TMDB API requests into typed tmdbFetch helper`, the variable was renamed to the more explicit `NEXT_PUBLIC_TMDB_API_KEY`.
A `|| NEXT_PUBLIC_API_KEY` fallback was kept temporarily in `utils/request.ts` to avoid breaking existing `.env` setups.
All environments have since been updated — this fallback is no longer needed.

## Changes
- `utils/request.ts` — simplify ENV resolution: remove fallback chain, use only `NEXT_PUBLIC_TMDB_API_KEY`
- `.env.example` — remove legacy `NEXT_PUBLIC_API_KEY` entry and its backward-compatibility comment
- `.github/workflows/ci.yml` — remove `NEXT_PUBLIC_API_KEY` from the CI mock env block

## Action Required (Local)
If you have a local `.env` file, manually remove the `NEXT_PUBLIC_API_KEY` line.
Only `NEXT_PUBLIC_TMDB_API_KEY` is required going forward.

## Testing
- `npx tsc --noEmit` — ✅ passed
