### PR TITLE
docs & chore: professionalize reference implementation branding and documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"[typescriptreact]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-# TMDB Streaming Architecture — Frontend Engineering Portfolio
+# TMDB Streaming Architecture — Production-Ready Reference Implementation
 
-This is not a simple "feature showcase" project. It is an engineering architecture proof-of-concept focused on **asynchronous state dependency chains** and **edge cases**. It demonstrates how to design a **predictable, foolproof, and highly defensive** state management system across three asynchronous data streams: **Firebase Auth (Identity)**, **Stripe (Subscription/Payment)**, and **TMDB (Static Data)**.
+This repository is a technical reference implementation of a streaming media frontend architecture, focusing on resolving **asynchronous state dependency chains** and **complex edge cases**. It demonstrates how to design a **predictable, error-resilient, and highly defensive** state management system integrated across three distinct asynchronous streams: **Firebase Auth (Identity)**, **Stripe (Subscription/Payment)**, and **TMDB (Static Media Catalog)**.
 
-- **Live Demo**: [stream.tinahu.dev](https://stream.tinahu.dev/)
-- **Demo Account**: Email `demo@tinahu.dev` / Password `Demo1234!` (Includes Stripe test subscription permissions)
+- **Live Showcase**: [stream.tinahu.dev](https://stream.tinahu.dev/)
+- **Test Credentials**: Email `demo@tinahu.dev` / Password `Demo1234!` (Includes Stripe test subscription permissions)
 
 [![Continuous Integration](https://github.com/yuting813/TMDB-Streaming-Architecture/actions/workflows/ci.yml/badge.svg)](https://github.com/yuting813/TMDB-Streaming-Architecture/actions)
 ![Next.js](https://img.shields.io/badge/Next.js-14-black?logo=next.js)
@@ -154,6 +154,8 @@ graph TD
 - **3-State Image Machine**: Every image component maintains three states—Loading (`animate-pulse` Skeleton to prevent CLS), Success (`opacity-100` fade-in to prevent flashing), and Failure (local fallback image to prevent broken links). `onError` simultaneously triggers `setIsLoaded(true)`, ensuring the skeleton instantly disappears once the fallback initiates. Implemented in both `Thumbnail.tsx` and `Modal.tsx`.
 - **Immutable Route Whitelist**: `Object.freeze(['/login', ...])` ensures that the Auth guard's judgment criteria cannot be accidentally mutated by any module at runtime.
 - **Jest Unit Testing**: Focused on `useSubscription`, utilizing Mock Firestore to test 6 boundary state machine transitions: `null user`, `empty list`, `onSnapshot error`, `loading`, `subscription active`, and `subscription inactive`, validating robustness under extreme scenarios.
+- **Fast Refresh Recoil Resiliency (HMR Crash Defense)**: In Next.js dev mode, Fast Refresh triggers module re-evaluation, which causes Recoil to throw a fatal duplicate atom key error. Bypassed this by programmatically configuring `RecoilEnv` checks in `pages/_app.tsx`, guaranteeing developer environment stability without compromising production performance.
+- **SVG Image Optimization & Layout Warnings**: Replaced Next.js `<Image>` components with standard `<img>` tags for static vector SVGs (e.g., `/logo.svg`). This prevents unnecessary server-side resizing overhead for vector graphics and avoids rendering conflict warnings caused by Tailwind CSS preflight's `height: auto` resets.
 
 ---
 
@@ -195,11 +197,11 @@ This project configures read/write permissions based on functional requirements:
 
 ---
 
-## About Me
+## Author & Engineering Philosophy
 
-My past 6 years in procurement management trained me to have a heightened sensitivity toward "Risk Control" and "Extreme Scenario Anticipation". While transitioning into a Frontend Engineer, I channeled this mindset into a pursuit of **Defensive Design**.
+Drawing from a background in risk management and scenario anticipation, I focus on **Defensive Frontend Engineering** and building highly resilient codebases.
 
-This project is the physical manifestation of that mindset: the three-state planning of every component, the interruption logic of every AbortSignal, and the caching of every layer of Promise requests all reflect my deep consideration for "How do we guarantee UI consistency when the system is imperfect?".
+This reference implementation demonstrates how to apply these risk-mitigation principles to asynchronous web applications—utilizing loading lifecycles for media assets, Safari-compatible stream cancelations, and strict route guarding to protect the user experience against network degradation.
 
 - **Website**: [tinahu.dev](https://www.tinahu.dev/)
 - **GitHub**: [yuting813](https://github.com/yuting813)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,11 +1,11 @@
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-# TMDB Streaming Architecture — Frontend Engineering Portfolio
+# TMDB Streaming Architecture — 穩健生產級前端參考實作
 
-這不是一個單純的「功能展示」專案。它是一個針對「非同步狀態依賴鏈」與「邊界極端情境（Edge Cases）」的工程架構驗證：展示如何在 **Firebase Auth（身份狀態）**、**Stripe（金流訂閱）** 與 **TMDB（靜態資料）** 這三條非同步資料流之間，設計出 **可預測、防呆且具備高度防禦性（Defensive Design）** 的狀態管理系統。
+本專案為串流媒體前端架構的**技術參考實作**，專注於解決**多重非同步資料流的狀態依賴**與**邊界極端情境（Edge Cases）**。本架構展示了如何在 **Firebase Auth（身份認證）**、**Stripe（金流訂閱）** 與 **TMDB（媒體資料）** 之間，建立一個**可預測、高容錯且具備防禦性設計（Defensive Design）**的狀態管理系統。
 
-- **Live Demo**: [stream.tinahu.dev](https://stream.tinahu.dev/)
-- **Demo 帳號**：Email `demo@tinahu.dev` / Password `Demo1234!`（含 Stripe 測試訂閱權限）
+- **線上參考部署**: [stream.tinahu.dev](https://stream.tinahu.dev/)
+- **測試憑證**：Email `demo@tinahu.dev` / Password `Demo1234!`（含 Stripe 測試訂閱權限）
 
 [![Continuous Integration](https://github.com/yuting813/TMDB-Streaming-Architecture/actions/workflows/ci.yml/badge.svg)](https://github.com/yuting813/TMDB-Streaming-Architecture/actions)
 ![Next.js](https://img.shields.io/badge/Next.js-14-black?logo=next.js)
@@ -154,6 +154,8 @@ graph TD
 - **圖片三態狀態機**：每個圖片元件維護三態——載入中（`animate-pulse` Skeleton 防止 CLS）、成功（`opacity-100` 淡入防閃跳）、失敗（本地 fallback 圖片防破圖）。`onError` 同時觸發 `setIsLoaded(true)`，確保 fallback 啟動後 skeleton 即時消失。`Thumbnail.tsx` 與 `Modal.tsx` 均有實作。
 - **不可變的路由白名單**：`Object.freeze(['/login', ...])` 確保 Auth 守衛的判斷基準在執行期不會被任何模組意外篡改。
 - **Jest 單元測試**：聚焦 `useSubscription`，使用 Mock Firestore 測試 6 種邊界狀態機切換：`null user`、`empty list`、`onSnapshot error`、`loading`、`subscription active`、`subscription inactive`，驗證極端情境下的強韌度。
+- **Fast Refresh Recoil 韌性（開發期崩潰防護）**：在 Next.js 開發模式下，Fast Refresh 會重新評估模組，導致 Recoil 拋出致命的重複 Atom Key 錯誤。我們在 `pages/_app.tsx` 中透過配置 `RecoilEnv` 停用開發期的重複檢測，確保熱更新（HMR）時的開發環境穩定性。
+- **SVG 向量圖優化與排版警告消除**：針對靜態 SVG 標誌（如 `/logo.svg`），將 Next.js `<Image>` 重構為原生 `<img>` 標籤。此舉免除了對向量圖進行不必要伺服器端最佳化的開銷，並根除了 Tailwind CSS Preflight 樣式覆蓋引發的瀏覽器主控台 `height: auto` 警告。
 
 ---
 
@@ -193,11 +195,11 @@ products/
 
 ---
 
-## 關於我
+## 作者與工程哲學
 
-過去 6 年的採購職涯，訓練出了對「風險控管」與「極端狀況預判」的高度敏感性。在轉職前端工程師的過程中，我將這份思維轉化為對**防禦性工程設計（Defensive Design）**的追求。
+結合過去在風險管理中對「極端情境預判」的敏感度，我將這份思維帶入軟體開發，專注於**防禦性前端工程**與程式庫韌性。
 
-這個專案正是這種思維的具象化：每一個元件的三態規劃、每一條 AbortSignal 的中斷邏輯，以及每一層 Promise 請求的緩存，都體現了我對於「當系統不完美時，我們如何保證 UI 一致性」的深度考量。
+本專案展示了如何將此原則應用於複雜的非同步系統：不論是串流媒體的三態狀態機、與舊版 Safari 相容的 AbortSignal 集中清理，還是多層路由防護鏈，皆力求在底層 API 或網路環境不穩定時，確保使用者體驗與系統狀態的完美一致。
 
 - **Website**: [tinahu.dev](https://www.tinahu.dev/)
 - **GitHub**: [yuting813](https://github.com/yuting813)

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -54,26 +54,30 @@ const AuthForm: React.FC<Props> = ({ mode, onSubmit, loading }) => {
 	return (
 		<form
 			onSubmit={handleSubmit(submit)}
-			className='relative space-y-8 py-10 px-6 rounded bg-black/75 md:max-w-md md:px-14'
+			className='relative space-y-8 rounded bg-black/75 px-6 py-10 md:max-w-md md:px-14'
 		>
-			<h1 className='text-4xl font-semibold '>{mode === 'login' ? '登入' : '註冊'}</h1>
+			<h1 className='text-4xl font-semibold'>{mode === 'login' ? '登入' : '註冊'}</h1>
 
 			{/* Demo Account Info Box - for Safe Browsing compliance */}
 			{mode === 'login' && (
 				<div className='rounded-lg border border-red-500/30 bg-red-900/10 p-4 text-sm'>
 					<p className='mb-2 flex items-center gap-2 font-semibold text-[#e50914]'>
-						Demo Account (Portfolio Project)
+						Test Credentials (Reference Implementation)
 					</p>
 					<div className='space-y-1 text-gray-300'>
-						<p>Email: <code className='rounded bg-black/30 px-1'>{DEMO_EMAIL}</code></p>
-						<p>Password: <code className='rounded bg-black/30 px-1'>{DEMO_PASSWORD}</code></p>
+						<p>
+							Email: <code className='rounded bg-black/30 px-1'>{DEMO_EMAIL}</code>
+						</p>
+						<p>
+							Password: <code className='rounded bg-black/30 px-1'>{DEMO_PASSWORD}</code>
+						</p>
 					</div>
 					<button
 						type='button'
 						onClick={handleFillDemo}
 						className='mt-3 w-full rounded bg-[#e50914] py-2 text-sm font-medium text-white transition hover:bg-[#b2070f]'
 					>
-						Use Demo Account
+						Use Test Account
 					</button>
 				</div>
 			)}
@@ -121,12 +125,13 @@ const AuthForm: React.FC<Props> = ({ mode, onSubmit, loading }) => {
 
 			<button
 				disabled={loading}
-				className={`w-full rounded py-3 font-semibold ${loading ? 'bg-[#e50914]/60' : 'bg-[#e50914] hover:bg-[#e50914]/80'
-					}`}
+				className={`w-full rounded py-3 font-semibold ${
+					loading ? 'bg-[#e50914]/60' : 'bg-[#e50914] hover:bg-[#e50914]/80'
+				}`}
 			>
 				{loading ? (
 					<div className='flex items-center justify-center'>
-						<svg className='animate-spin h-5 w-5 text-white' viewBox='0 0 24 24'>
+						<svg className='h-5 w-5 animate-spin text-white' viewBox='0 0 24 24'>
 							<circle
 								className='opacity-25'
 								cx='12'

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,14 +3,18 @@ function Footer() {
 		<footer className='w-full bg-black/60 py-6 text-center text-[10px] text-gray-500 md:text-sm'>
 			<div className='mx-auto flex w-full max-w-7xl flex-col items-center justify-center space-y-2 px-4'>
 				<p className='font-semibold text-gray-400'>
-					DISCLAIMER: This is a Portfolio Project for Educational Purposes Only
+					DISCLAIMER: This is a Reference Project for Educational Purposes Only
 				</p>
-					<p>
-					This website is an educational portfolio project created to demonstrate full-stack
-					development skills. It is NOT a commercial service and is NOT affiliated with, endorsed
-					by, or associated with any official streaming platforms or existing media corporations.
+				<p>
+					This website is an educational reference project created to demonstrate technical
+					architecture and system integrations. It is NOT a commercial service and is NOT affiliated
+					with, endorsed by, or associated with any official streaming platforms or existing media
+					corporations.
 				</p>
-				<p>⚠️ Demo credentials are provided above — No real personal data is collected or stored.</p>
+				<p>
+					⚠️ Test credentials are provided on the login page — No real personal data is collected or
+					stored.
+				</p>
 				<p className='mt-2'>&copy; {new Date().getFullYear()} - Built by Tina Hu</p>
 			</div>
 		</footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { SearchIcon } from '@heroicons/react/solid';
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';

--- a/components/Plans.tsx
+++ b/components/Plans.tsx
@@ -1,7 +1,6 @@
 import { CheckIcon } from '@heroicons/react/outline';
 import { Product } from '@invertase/firestore-stripe-payments';
 import Head from 'next/head';
-import Image from 'next/image';
 import Link from 'next/link';
 import React, { useState } from 'react';
 import useAuth from '@/hooks/useAuth';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,7 @@ export default function Document() {
 			<Head>
 				<meta
 					name='description'
-					content='Stream - Frontend Engineering Portfolio by Tina Hu. Educational demonstration project showcasing Next.js, Firebase, Stripe integration. NOT a commercial service.'
+					content='Stream - Production-Ready Reference Implementation by Tina Hu. Technical showcase demonstrating Next.js, Firebase, and Stripe integration. NOT a commercial service.'
 				/>
 				<link rel='icon' href='/logo.svg' type='image/svg+xml' />
 				<link rel='apple-touch-icon' href='/logo.png' />

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -34,13 +34,13 @@ function Login() {
 	return (
 		<div className='relative flex h-screen w-screen flex-col bg-black md:items-center md:justify-center md:bg-transparent'>
 			<Head>
-				<title>Stream Demo - Portfolio Project by Tina Hu</title>
+				<title>Stream - Reference Implementation by Tina Hu</title>
 			</Head>
 
-			{/* Portfolio Disclaimer Banner */}
+			{/* Educational Disclaimer Banner */}
 			<div className='fixed left-0 right-0 top-0 z-50 border-b border-white/10 bg-black/80 px-4 py-3 text-center text-xs font-light tracking-wide text-gray-300 shadow-lg backdrop-blur-sm md:text-sm'>
 				<span className='hidden sm:inline'>This is a </span>
-				<span className='font-bold text-white'>Portfolio Demo</span>
+				<span className='font-bold text-white'>Reference Showcase</span>
 				{' — '}
 				<span className='block sm:inline'>
 					NOT affiliated with Netflix

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -31,13 +31,13 @@ function Signup() {
 	return (
 		<div className='relative flex h-screen w-screen flex-col bg-black md:items-center md:justify-center md:bg-transparent'>
 			<Head>
-				<title>Stream Demo - Portfolio Project by Tina Hu</title>
+				<title>Stream - Reference Implementation by Tina Hu</title>
 			</Head>
 
-			{/* Portfolio Disclaimer Banner */}
+			{/* Educational Disclaimer Banner */}
 			<div className='fixed left-0 right-0 top-0 z-50 border-b border-white/10 bg-black/80 px-4 py-3 text-center text-xs font-light tracking-wide text-gray-300 shadow-lg backdrop-blur-sm md:text-sm'>
 				<span className='hidden sm:inline'>This is a </span>
-				<span className='font-bold text-white'>Portfolio Demo</span>
+				<span className='font-bold text-white'>Reference Showcase</span>
 				{' — '}
 				<span className='block sm:inline'>
 					NOT affiliated with Netflix


### PR DESCRIPTION
## Summary
This PR refactors user-facing UI labels, metadata, and markdown documentation to transition the project's terminology from "portfolio/demo" to "reference implementation/test showcase".

## Proposed Changes

### 1. Documentation & Architecture Philosophy
* **README.md & README.zh-TW.md**:
  * Refactored opening paragraphs to present the codebase directly as a "technical reference implementation of a streaming media frontend architecture".
  * Re-framed the author profile section to "Author & Engineering Philosophy" " to focus on defensive design principles and codebase stability.
  * Added documentation details for recent architectural fixes (Fast Refresh Recoil crash resolution and static SVG logo warning bypasses).

### 2. Codebase Branding & Disclaimer Realignment
* **Metadata & Page Titles**: Updated `<title>` tags and page descriptions in `_document.tsx`, `login.tsx`, and `signup.tsx` to use "Reference Implementation" and "Reference Showcase".
* **Banners & Buttons**: Updated the credentials banner and autofill button in `AuthForm.tsx` from "Demo Account" to "Test Credentials" / "Use Test Account".
* **Footer**: Updated `Footer.tsx` disclaimer text to refer to the project as an "educational reference project" using standard testing terminology.

### 3. Code Quality & Formatting Cleanups
* **Imports**: Removed unused `next/image` import declarations from `Header.tsx` and `Plans.tsx` left over from the logo SVG refactor.
* **VS Code Settings**: Updated `.vscode/settings.json` code action configurations to use the modern `"explicit"` format.

## Verification
- [x] Ran `npm run lint` — 0 errors, 0 warnings.
- [x] Ran `npm run build` — Compiled successfully (optimized production build generated).
