### PR TITLE
fix(recoil): disable duplicate atom key check in dev/SSR mode to avoid HMR crashes

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,12 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
-import { RecoilRoot } from 'recoil';
+import { RecoilEnv, RecoilRoot } from 'recoil';
 import { AuthProvider } from '../hooks/useAuth';
+
+// Disable Recoil duplicate atom key checking to prevent crashes during Next.js Hot Module Replacement (HMR) and Server-Side Rendering (SSR)
+if (process.env.NODE_ENV !== 'production') {
+	RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
+}
 
 function MyApp({ Component, pageProps }: AppProps) {
 	return (


### PR DESCRIPTION
## Summary
This PR programmatically configures the Recoil environment to disable duplicate atom key checks during local development and Server-Side Rendering (SSR) module re-evaluations.

## Proposed Changes
* **Recoil Env (`_app.tsx`)**: Configured `RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false` when running in dev/non-production mode. This prevents Next.js Fast Refresh (HMR) from throwing fatal duplicate atom key violations.

## Verification
- [x] Tested locally via `npm run dev` with multiple module updates; Fast Refresh reloads without crashing.
- [x] Verified build compiles successfully with `npm run build`.
