### PR TITLE
feat: sort My List by recently added

### DIFF
--- a/__tests__/hooks/useList.test.tsx
+++ b/__tests__/hooks/useList.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { onSnapshot } from 'firebase/firestore';
+import useList from '../../hooks/useList';
+
+jest.mock('../../firebase', () => ({
+	db: {},
+}));
+
+jest.mock('firebase/firestore', () => ({
+	collection: jest.fn(),
+	onSnapshot: jest.fn(),
+}));
+
+describe('useList', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('sorts recently added titles first and keeps legacy titles without addedAt last', async () => {
+		(onSnapshot as jest.Mock).mockImplementation((_collection, onNext) => {
+			onNext({
+				docs: [
+					{
+						id: 'legacy',
+						data: () => ({ title: 'Legacy title' }),
+					},
+					{
+						id: 'newest',
+						data: () => ({
+							title: 'Newest title',
+							addedAt: { toMillis: () => 200 },
+						}),
+					},
+					{
+						id: 'older',
+						data: () => ({
+							title: 'Older title',
+							addedAt: { toMillis: () => 100 },
+						}),
+					},
+				],
+			});
+
+			return jest.fn();
+		});
+
+		const { result } = renderHook(() => useList('test-user-id'));
+
+		await waitFor(() => {
+			expect(result.current.map((movie) => movie.title)).toEqual([
+				'Newest title',
+				'Older title',
+				'Legacy title',
+			]);
+		});
+	});
+});

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, PlusIcon, ThumbUpIcon, VolumeOffIcon, XIcon } from '@heroicons/react/outline';
 import { VolumeUpIcon } from '@heroicons/react/solid';
 import MuiModal from '@mui/material/Modal';
-import { deleteDoc, doc, setDoc } from 'firebase/firestore';
+import { deleteDoc, doc, serverTimestamp, setDoc } from 'firebase/firestore';
 import Image from 'next/image';
 import { useRecoilState } from 'recoil';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -131,7 +131,10 @@ function Modal() {
 				style: toastStyle,
 			});
 		} else {
-			await setDoc(doc(db, 'customers', user.uid, 'myList', movie.id.toString()), { ...movie });
+			await setDoc(doc(db, 'customers', user.uid, 'myList', movie.id.toString()), {
+				...movie,
+				addedAt: serverTimestamp(),
+			});
 			toast(`${movie?.title || movie?.original_name} has been added to My List`, {
 				duration: 8000,
 				style: toastStyle,

--- a/hooks/useList.tsx
+++ b/hooks/useList.tsx
@@ -1,21 +1,27 @@
-import { collection, DocumentData, onSnapshot } from 'firebase/firestore';
+import { collection, onSnapshot } from 'firebase/firestore';
+import type { DocumentData, Timestamp } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from '../firebase';
 import { Movie } from '../typings';
 
+type ListItem = (Movie | DocumentData) & {
+	addedAt?: Timestamp | null;
+};
+
 function useList(uid: string | undefined) {
-	const [list, setList] = useState<Movie[] | DocumentData[]>([]);
+	const [list, setList] = useState<ListItem[]>([]);
 
 	useEffect(() => {
 		if (!uid) return;
 
 		return onSnapshot(collection(db, 'customers', uid, 'myList'), (snapshot) => {
-			setList(
-				snapshot.docs.map((doc) => ({
-					id: doc.id,
-					...doc.data(),
-				})),
-			);
+			const movies = snapshot.docs.map((doc) => ({
+				id: doc.id,
+				...doc.data(),
+			})) as ListItem[];
+
+			movies.sort((a, b) => (b.addedAt?.toMillis() ?? 0) - (a.addedAt?.toMillis() ?? 0));
+			setList(movies);
 		});
 	}, [uid]);
 


### PR DESCRIPTION
## Summary

- store a server-generated `addedAt` timestamp when a title is added to My List
- sort My List from most recently added to oldest
- keep legacy Firestore documents without `addedAt` visible after timestamped titles
- add a regression test for ordering and legacy-data compatibility

## Why

My List previously inherited Firestore's document ID order. Because document IDs are TMDB movie IDs, the displayed order did not represent recency or title order and had no clear meaning for users.

## Trade-offs

Sorting remains client-side so existing documents without `addedAt` are preserved. Their original add times cannot be reconstructed, so they appear after timestamped titles.

If the list later requires pagination or larger-scale querying, the next step would be to backfill timestamps and move ordering into Firestore.

## Validation

- `npm run lint`
- `npx tsc --noEmit --pretty false`
- `npm test -- --runInBand __tests__/hooks/useList.test.tsx`
- `npm run build`